### PR TITLE
Restyle navigation bar for cinematic hero blend

### DIFF
--- a/src/components/NavigationBar/NavigationBar.styled.ts
+++ b/src/components/NavigationBar/NavigationBar.styled.ts
@@ -1,45 +1,14 @@
 import styled from "styled-components";
 
 // Main Navigation Container
-export const NavContainer = styled.nav<{ isScrolled: boolean }>`
-  position: sticky;
-  top: 0;
-  left: 0;
+export const NavContainer = styled.nav`
+  position: relative;
   width: 100%;
   z-index: 1000;
-  background: ${({ isScrolled }) =>
-    isScrolled ? "rgba(10, 10, 10, 0.92)" : "transparent"};
-  backdrop-filter: ${({ isScrolled }) =>
-    isScrolled ? "blur(18px)" : "saturate(140%) blur(12px)"};
-  border-bottom: ${({ isScrolled }) =>
-    isScrolled ? "1px solid rgba(255, 255, 255, 0.08)" : "none"};
-  box-shadow: ${({ isScrolled }) =>
-    isScrolled ? "0 12px 32px rgba(0, 0, 0, 0.45)" : "none"};
-  transition: background 0.35s ease, backdrop-filter 0.35s ease,
-    border-bottom 0.35s ease, box-shadow 0.35s ease;
-  isolation: isolate;
-
-  @supports not (backdrop-filter: blur(0)) {
-    backdrop-filter: none;
-    background: ${({ isScrolled }) =>
-      isScrolled
-        ? "rgba(10, 10, 10, 0.92)"
-        : "linear-gradient(180deg, rgba(0, 0, 0, 0.85) 0%, rgba(0, 0, 0, 0.5) 55%, rgba(0, 0, 0, 0) 100%)"};
-  }
-
-  &::after {
-    content: "";
-    position: absolute;
-    z-index: -1;
-    left: 0;
-    right: 0;
-    bottom: -48px;
-    height: 48px;
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0.45) 0%, rgba(0, 0, 0, 0) 100%);
-    opacity: ${({ isScrolled }) => (isScrolled ? 0 : 1)};
-    transition: opacity 0.35s ease;
-    pointer-events: none;
-  }
+  background: transparent;
+  backdrop-filter: none;
+  border-bottom: none;
+  box-shadow: none;
 `;
 
 // Navigation Content Wrapper
@@ -49,99 +18,248 @@ export const NavContent = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 2rem;
-  height: 70px;
-  max-width: 1200px;
+  gap: 2rem;
+  padding: 0 3rem;
+  height: 76px;
+  max-width: 1300px;
   margin: 0 auto;
+  width: 100%;
+
+  @media (max-width: 1024px) {
+    padding: 0 2rem;
+    height: 72px;
+  }
+
+  @media (max-width: 768px) {
+    padding: 0 1.25rem;
+    height: 64px;
+    gap: 1.25rem;
+  }
+`;
+
+export const NavLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 2.5rem;
+  flex: 1;
+  min-width: 0;
+
+  @media (max-width: 1024px) {
+    gap: 1.75rem;
+  }
+`;
+
+export const NavRight = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1.5rem;
+  flex: 1;
+  min-width: 0;
+
+  @media (max-width: 1024px) {
+    gap: 1.25rem;
+  }
+
+  @media (max-width: 768px) {
+    gap: 0.75rem;
+    flex: initial;
+  }
 `;
 
 // Logo Section
 export const LogoSection = styled.div`
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 `;
 
 export const Logo = styled.div`
-  font-size: 1.8rem;
-  font-weight: bold;
-  color: ${({ theme }) => theme.colors.primary || "#e50914"};
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: #ffffff;
   text-decoration: none;
   cursor: pointer;
-  transition: all 0.3s ease;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition: transform 0.3s ease, opacity 0.3s ease;
 
   &:hover {
-    color: #d70712;
-    text-shadow: 0 2px 8px rgba(229, 9, 20, 0.4);
+    transform: translateY(-1px);
+    opacity: 0.95;
+  }
+`;
+
+export const LogoMark = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #ff5a63 0%, #e50914 60%, #b20710 100%);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  box-shadow: 0 12px 26px rgba(229, 9, 20, 0.4);
+`;
+
+export const LogoText = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: inherit;
+
+  strong {
+    color: ${({ theme }) => theme.colors.primary || "#e50914"};
+    font-weight: inherit;
   }
 `;
 
 // Navigation Links
-export const NavLinks = styled.div`
+export const NavLinks = styled.nav`
   display: flex;
   align-items: center;
   gap: 2rem;
+
+  @media (max-width: 1024px) {
+    gap: 1.5rem;
+  }
 
   @media (max-width: 768px) {
     display: none;
   }
 `;
 
-export const NavLink = styled.a`
-  color: rgba(255, 255, 255, 0.9);
+export const NavLink = styled.a<{ $isActive?: boolean }>`
+  position: relative;
+  color: ${({ $isActive }) =>
+    $isActive ? "rgba(255, 255, 255, 0.95)" : "rgba(255, 255, 255, 0.72)"};
   text-decoration: none;
   font-weight: 500;
-  font-size: 1rem;
-  transition: all 0.3s ease;
-  cursor: pointer;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  transition: color 0.3s ease;
 
-  &:hover {
-    color: ${({ theme }) => theme.colors.primary || "#e50914"};
-    background: rgba(255, 255, 255, 0.1);
+  &:hover,
+  &:focus-visible {
+    color: #ffffff;
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -0.55rem;
+    width: 100%;
+    height: 2px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #ff5a63 0%, #e50914 100%);
+    transform: ${({ $isActive }) => ($isActive ? "scaleX(1)" : "scaleX(0)")};
+    opacity: ${({ $isActive }) => ($isActive ? 1 : 0)};
+    transform-origin: left center;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+  }
+
+  &:hover::after,
+  &:focus-visible::after {
+    transform: scaleX(1);
+    opacity: 1;
+  }
+`;
+
+export const IconGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: rgba(255, 255, 255, 0.8);
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`;
+
+export const IconButton = styled.button`
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.05rem;
+  cursor: pointer;
+  padding: 0.35rem;
+  border-radius: 999px;
+  transition: color 0.3s ease, background-color 0.3s ease, transform 0.3s ease;
+
+  &:hover,
+  &:focus-visible {
+    color: #ffffff;
+    background: rgba(255, 255, 255, 0.14);
+    transform: translateY(-1px);
   }
 `;
 
 // User Section (for authenticated users)
 export const UserSection = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 1rem;
 `;
 
-export const UserProfile = styled.div`
+export const UserProfile = styled.button<{ $isOpen: boolean }>`
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.65rem;
   cursor: pointer;
-  padding: 0.5rem;
-  border-radius: 4px;
-  transition: background-color 0.3s ease;
+  padding: 0.3rem 0.75rem 0.3rem 0.35rem;
+  border-radius: 999px;
+  border: 1px solid
+    ${({ $isOpen }) =>
+      $isOpen ? "rgba(255, 255, 255, 0.32)" : "rgba(255, 255, 255, 0.18)"};
+  background: ${({ $isOpen }) =>
+    $isOpen ? "rgba(255, 255, 255, 0.16)" : "rgba(255, 255, 255, 0.1)"};
+  transition: background-color 0.3s ease, border-color 0.3s ease,
+    box-shadow 0.3s ease, transform 0.3s ease;
+  color: inherit;
 
-  &:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+  &:hover,
+  &:focus-visible {
+    background: rgba(255, 255, 255, 0.18);
+    border-color: rgba(255, 255, 255, 0.32);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
   }
 `;
 
 export const UserAvatar = styled.div`
-  width: 32px;
-  height: 32px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
-  background: ${({ theme }) => theme.colors.primary || "#e50914"};
+  background: linear-gradient(135deg, #ff5a63 0%, #e50914 60%, #b20710 100%);
   display: flex;
   align-items: center;
   justify-content: center;
   color: white;
   font-weight: bold;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
+  box-shadow: 0 8px 20px rgba(229, 9, 20, 0.35);
 `;
 
 export const UserName = styled.span`
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(255, 255, 255, 0.85);
   font-weight: 500;
   font-size: 0.9rem;
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`;
+
+export const UserChevron = styled.span<{ $isOpen: boolean }>`
+  font-size: 0.7rem;
+  color: ${({ $isOpen }) =>
+    $isOpen ? "rgba(255, 255, 255, 0.95)" : "rgba(255, 255, 255, 0.65)"};
+  transform: ${({ $isOpen }) => ($isOpen ? "rotate(180deg)" : "rotate(0deg)")};
+  transition: transform 0.3s ease, color 0.3s ease;
 
   @media (max-width: 768px) {
     display: none;
@@ -152,102 +270,120 @@ export const UserName = styled.span`
 export const AuthButtons = styled.div`
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.85rem;
 `;
 
-export const AuthButton = styled.button<{ variant?: 'primary' | 'secondary' }>`
-  padding: 0.6rem 1.2rem;
-  border-radius: 4px;
-  font-weight: 500;
+export const AuthButton = styled.button<{ variant?: "primary" | "secondary" }>`
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
   font-size: 0.9rem;
   cursor: pointer;
   transition: all 0.3s ease;
   border: none;
+  color: white;
 
   ${({ variant, theme }) => {
-    if (variant === 'primary') {
+    if (variant === "primary") {
       return `
-        background: ${theme.colors.primary || "#e50914"};
-        color: white;
-        box-shadow: 0 2px 8px rgba(229, 9, 20, 0.3);
-        
-        &:hover {
-          background: #d70712;
-          box-shadow: 0 4px 12px rgba(229, 9, 20, 0.4);
-        }
-      `;
-    } else {
-      return `
-        background: rgba(255, 255, 255, 0.1);
-        color: rgba(255, 255, 255, 0.9);
-        border: 1px solid rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
-        
-        &:hover {
-          background: rgba(255, 255, 255, 0.2);
-          border-color: rgba(255, 255, 255, 0.4);
-          color: white;
+        background: linear-gradient(135deg, #ff5a63 0%, ${
+          theme.colors.primary || "#e50914"
+        } 55%, #b20710 100%);
+        box-shadow: 0 14px 30px rgba(229, 9, 20, 0.35);
+
+        &:hover,
+        &:focus-visible {
+          background: linear-gradient(135deg, #ff6b74 0%, ${
+            theme.colors.primary || "#e50914"
+          } 50%, #b20710 100%);
+          box-shadow: 0 18px 36px rgba(229, 9, 20, 0.45);
+          transform: translateY(-1px);
         }
       `;
     }
+
+    return `
+      background: rgba(255, 255, 255, 0.12);
+      color: rgba(255, 255, 255, 0.9);
+      border: 1px solid rgba(255, 255, 255, 0.22);
+
+      &:hover,
+      &:focus-visible {
+        background: rgba(255, 255, 255, 0.18);
+        border-color: rgba(255, 255, 255, 0.32);
+        color: #ffffff;
+      }
+    `;
   }}
+
+  @media (max-width: 480px) {
+    padding: 0.5rem 1.15rem;
+  }
 `;
 
 // Mobile Menu Button
 export const MobileMenuButton = styled.button`
   display: none;
-  background: none;
-  border: none;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 12px;
   color: ${({ theme }) => theme.colors.text || "#fff"};
-  font-size: 1.5rem;
+  font-size: 1.35rem;
   cursor: pointer;
-  padding: 0.5rem;
+  transition: background 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(255, 255, 255, 0.18);
+    border-color: rgba(255, 255, 255, 0.3);
+    transform: translateY(-1px);
+  }
 
   @media (max-width: 768px) {
-    display: block;
+    display: flex;
   }
 `;
 
 // Dropdown Menu
 export const DropdownMenu = styled.div<{ isOpen: boolean }>`
   position: absolute;
-  top: 100%;
+  top: calc(100% + 0.6rem);
   right: 0;
-  background: rgba(0, 0, 0, 0.9);
-  backdrop-filter: blur(15px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
-  min-width: 200px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  background: rgba(12, 12, 12, 0.96);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  min-width: 220px;
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.45);
   opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
-  visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
-  transform: ${({ isOpen }) => (isOpen ? 'translateY(0)' : 'translateY(-10px)')};
+  visibility: ${({ isOpen }) => (isOpen ? "visible" : "hidden")};
+  transform: ${({ isOpen }) =>
+    isOpen ? "translateY(0)" : "translateY(-12px)"};
   transition: all 0.3s ease;
   z-index: 1001;
+  padding: 0.5rem;
 `;
 
 export const DropdownItem = styled.button`
   width: 100%;
-  padding: 0.8rem 1rem;
+  padding: 0.75rem 0.9rem;
   background: none;
   border: none;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(255, 255, 255, 0.85);
   text-align: left;
   cursor: pointer;
   transition: all 0.3s ease;
-  font-size: 0.9rem;
+  font-size: 0.92rem;
+  border-radius: 12px;
 
-  &:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: white;
-  }
-
-  &:first-child {
-    border-radius: 8px 8px 0 0;
-  }
-
-  &:last-child {
-    border-radius: 0 0 8px 8px;
+  &:hover,
+  &:focus-visible {
+    background: rgba(255, 255, 255, 0.12);
+    color: #ffffff;
   }
 `;
 
@@ -262,32 +398,41 @@ export const SearchContainer = styled.div`
   }
 `;
 
-export const SearchInput = styled.input`
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 20px;
-  padding: 0.5rem 1rem 0.5rem 2.5rem;
-  color: rgba(255, 255, 255, 0.9);
-  font-size: 0.9rem;
-  width: 250px;
+export const SearchForm = styled.form<{ $isFocused: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  border-radius: 999px;
+  padding: 0.4rem 0.75rem 0.4rem 0.9rem;
+  background: ${({ $isFocused }) =>
+    $isFocused ? "rgba(255, 255, 255, 0.18)" : "rgba(255, 255, 255, 0.12)"};
+  border: 1px solid
+    ${({ $isFocused }) =>
+      $isFocused ? "rgba(255, 255, 255, 0.3)" : "rgba(255, 255, 255, 0.18)"};
+  box-shadow: ${({ $isFocused }) =>
+    $isFocused ? "0 16px 34px rgba(0, 0, 0, 0.35)" : "none"};
   transition: all 0.3s ease;
-  backdrop-filter: blur(10px);
+`;
+
+export const SearchInput = styled.input<{ $isFocused: boolean }>`
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 0.95rem;
+  width: ${({ $isFocused }) => ($isFocused ? "220px" : "140px")};
+  transition: width 0.3s ease, color 0.3s ease;
 
   &::placeholder {
-    color: rgba(255, 255, 255, 0.5);
+    color: rgba(255, 255, 255, 0.6);
   }
 
   &:focus {
     outline: none;
-    border-color: ${({ theme }) => theme.colors.primary || "#e50914"};
-    background: rgba(0, 0, 0, 0.5);
-    box-shadow: 0 0 0 2px rgba(229, 9, 20, 0.2);
   }
 `;
 
-export const SearchIcon = styled.div`
-  position: absolute;
-  left: 0.8rem;
-  color: rgba(255, 255, 255, 0.6);
+export const SearchIcon = styled.span`
+  color: rgba(255, 255, 255, 0.75);
   font-size: 1rem;
+  line-height: 1;
 `;

--- a/src/components/NavigationBar/NavigationBar.view.tsx
+++ b/src/components/NavigationBar/NavigationBar.view.tsx
@@ -1,42 +1,63 @@
-import React, { useState, useRef, useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import React, { useEffect, useRef, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
 import {
   NavContainer,
   NavContent,
+  NavLeft,
+  NavRight,
   LogoSection,
   Logo,
+  LogoMark,
+  LogoText,
   NavLinks,
   NavLink,
+  IconGroup,
+  IconButton,
   UserSection,
   UserProfile,
   UserAvatar,
   UserName,
+  UserChevron,
   AuthButtons,
   AuthButton,
   MobileMenuButton,
   DropdownMenu,
   DropdownItem,
   SearchContainer,
+  SearchForm,
   SearchInput,
   SearchIcon,
 } from "./NavigationBar.styled";
 
+const NAVIGATION_LINKS = [
+  { label: "Home", path: "/" },
+  { label: "Movies", path: "/movies" },
+  { label: "TV Shows", path: "/tvshows" },
+  { label: "My List", path: "/my-list" },
+] as const;
+
 export const NavigationBar: React.FC = () => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [isScrolled, setIsScrolled] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);\r\n\r\n  useEffect(() => {\r\n    if (typeof window === "undefined") {\r\n      return;\r\n    }\r\n\r\n    const handleScroll = () => {\r\n      setIsScrolled(window.scrollY > 40);\r\n    };\r\n\r\n    handleScroll();\r\n\r\n    window.addEventListener("scroll", handleScroll);\r\n    return () => {\r\n      window.removeEventListener("scroll", handleScroll);\r\n    };\r\n  }, []);\r\n\r\n  // Close dropdown when clicking outside
+  const [isSearchFocused, setIsSearchFocused] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
         setIsDropdownOpen(false);
       }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
+
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
@@ -48,107 +69,151 @@ export const NavigationBar: React.FC = () => {
     navigate("/");
   };
 
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (searchQuery.trim()) {
       // TODO: Implement search functionality
       console.log("Searching for:", searchQuery);
     }
   };
 
-  const getInitials = (name: string) => {
-    return name
+  const getInitials = (name: string) =>
+    name
       .split(" ")
-      .map((n) => n[0])
+      .map((part) => part[0])
       .join("")
       .toUpperCase()
       .slice(0, 2);
+
+  const isPathActive = (path: string) => {
+    if (path === "/") {
+      return location.pathname === "/";
+    }
+
+    return location.pathname.startsWith(path);
   };
 
   return (
-    <NavContainer isScrolled={isScrolled}>
+    <NavContainer>
       <NavContent>
-        {/* Logo Section */}
-        <LogoSection>
-          <Link to="/" style={{ textDecoration: "none" }}>
-            <Logo>StreamFlix</Logo>
-          </Link>
-        </LogoSection>
+        <NavLeft>
+          <LogoSection>
+            <Link to="/" style={{ textDecoration: "none" }}>
+              <Logo>
+                <LogoMark>S</LogoMark>
+                <LogoText>
+                  Stream<strong>Flix</strong>
+                </LogoText>
+              </Logo>
+            </Link>
+          </LogoSection>
 
-        {/* Navigation Links - Only show for authenticated users */}
-        {user && (
-          <NavLinks>
-            <NavLink as={Link} to="/">
-              Home
-            </NavLink>
-            <NavLink as={Link} to="/movies">
-              Movies
-            </NavLink>
-            <NavLink as={Link} to="/tvshows">
-              TV Shows
-            </NavLink>
-            <NavLink as={Link} to="/my-list">
-              My List
-            </NavLink>
-          </NavLinks>
-        )}
+          {user && (
+            <NavLinks>
+              {NAVIGATION_LINKS.map((link) => (
+                <NavLink
+                  key={link.path}
+                  as={Link}
+                  to={link.path}
+                  $isActive={isPathActive(link.path)}
+                >
+                  {link.label}
+                </NavLink>
+              ))}
+            </NavLinks>
+          )}
+        </NavLeft>
 
-        {/* Search Bar - Only show for authenticated users */}
-        {user && (
-          <SearchContainer>
-            <form onSubmit={handleSearch}>
-              <SearchIcon>🔍</SearchIcon>
-              <SearchInput
-                type="text"
-                placeholder="Search movies, TV shows..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              />
-            </form>
-          </SearchContainer>
-        )}
+        <NavRight>
+          {user && (
+            <>
+              <SearchContainer>
+                <SearchForm
+                  onSubmit={handleSearch}
+                  $isFocused={isSearchFocused || Boolean(searchQuery)}
+                >
+                  <SearchIcon aria-hidden="true">🔍</SearchIcon>
+                  <SearchInput
+                    type="text"
+                    placeholder="Titles, people, genres"
+                    value={searchQuery}
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                    onFocus={() => setIsSearchFocused(true)}
+                    onBlur={() => setIsSearchFocused(false)}
+                    $isFocused={isSearchFocused || Boolean(searchQuery)}
+                    aria-label="Search titles"
+                  />
+                </SearchForm>
+              </SearchContainer>
 
-        {/* User Section or Auth Buttons */}
-        {user ? (
-          <UserSection>
-            <UserProfile
-              ref={dropdownRef}
-              onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-            >
-              <UserAvatar>{getInitials(user.username)}</UserAvatar>
-              <UserName>{user.username}</UserName>
-            </UserProfile>
+              <IconGroup>
+                <IconButton type="button" aria-label="Help center">
+                  ?
+                </IconButton>
+                <IconButton type="button" aria-label="Notifications">
+                  🔔
+                </IconButton>
+              </IconGroup>
+            </>
+          )}
 
-            <DropdownMenu isOpen={isDropdownOpen}>
-              <DropdownItem onClick={() => navigate("/profile")}>
-                Profile
-              </DropdownItem>
-              <DropdownItem onClick={() => navigate("/settings")}>
-                Settings
-              </DropdownItem>
-              <DropdownItem onClick={() => navigate("/my-list")}>
-                My List
-              </DropdownItem>
-              <DropdownItem onClick={handleLogout}>
-                Logout
-              </DropdownItem>
-            </DropdownMenu>
-          </UserSection>
-        ) : (
-          <AuthButtons>
-            <AuthButton as={Link} to="/login" variant="secondary">
-              Sign In
-            </AuthButton>
-            <AuthButton as={Link} to="/signup" variant="primary">
-              Sign Up
-            </AuthButton>
-          </AuthButtons>
-        )}
+          {user ? (
+            <UserSection ref={dropdownRef}>
+              <UserProfile
+                type="button"
+                onClick={() => setIsDropdownOpen((prev) => !prev)}
+                $isOpen={isDropdownOpen}
+              >
+                <UserAvatar>{getInitials(user.username)}</UserAvatar>
+                <UserName>{user.username}</UserName>
+                <UserChevron $isOpen={isDropdownOpen} aria-hidden="true">
+                  ▾
+                </UserChevron>
+              </UserProfile>
 
-        {/* Mobile Menu Button */}
-        <MobileMenuButton>
-          ☰
-        </MobileMenuButton>
+              <DropdownMenu isOpen={isDropdownOpen}>
+                <DropdownItem
+                  onClick={() => {
+                    setIsDropdownOpen(false);
+                    navigate("/profile");
+                  }}
+                >
+                  Profile
+                </DropdownItem>
+                <DropdownItem
+                  onClick={() => {
+                    setIsDropdownOpen(false);
+                    navigate("/settings");
+                  }}
+                >
+                  Settings
+                </DropdownItem>
+                <DropdownItem
+                  onClick={() => {
+                    setIsDropdownOpen(false);
+                    navigate("/my-list");
+                  }}
+                >
+                  My List
+                </DropdownItem>
+                <DropdownItem onClick={handleLogout}>Logout</DropdownItem>
+              </DropdownMenu>
+            </UserSection>
+          ) : (
+            <AuthButtons>
+              <AuthButton as={Link} to="/login" variant="secondary">
+                Sign In
+              </AuthButton>
+              <AuthButton as={Link} to="/signup" variant="primary">
+                Sign Up
+              </AuthButton>
+            </AuthButtons>
+          )}
+
+          <MobileMenuButton type="button" aria-label="Open navigation">
+            ☰
+          </MobileMenuButton>
+        </NavRight>
       </NavContent>
     </NavContainer>
   );


### PR DESCRIPTION
## Summary
- restyle the navigation container with a transparent, non-sticky layout so it blends into the hero artwork
- redesign the navigation content with a logo mark, active link styling, and icon actions that mirror the reference look
- modernize the user/profile controls, dropdown menu, and search pill for a cohesive glassmorphism experience

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*
- npx eslint src/components/NavigationBar

------
https://chatgpt.com/codex/tasks/task_e_68d023256f748325bc622c664e1efd00