### PR TITLE
Adjust navigation bar to overlay hero section

### DIFF
--- a/src/components/NavigationBar/NavigationBar.styled.ts
+++ b/src/components/NavigationBar/NavigationBar.styled.ts
@@ -1,52 +1,11 @@
 import styled from "styled-components";
 
 // Main Navigation Container
-export const NavContainer = styled.nav<{ isScrolled: boolean }>`
-  position: sticky;
-  top: 0;
-  left: 0;
+export const NavContainer = styled.nav`
+  position: relative;
   width: 100%;
   z-index: 1000;
-  background: ${({ isScrolled }) =>
-    isScrolled
-      ? "rgba(6, 6, 6, 0.94)"
-      : "linear-gradient(180deg, rgba(6, 6, 6, 0.9) 0%, rgba(6, 6, 6, 0.45) 55%, rgba(6, 6, 6, 0) 100%)"};
-  backdrop-filter: ${({ isScrolled }) => (isScrolled ? "blur(16px)" : "none")};
-  border-bottom: ${({ isScrolled }) =>
-    isScrolled ? "1px solid rgba(255, 255, 255, 0.08)" : "1px solid transparent"};
-  box-shadow: ${({ isScrolled }) =>
-    isScrolled ? "0 18px 36px rgba(0, 0, 0, 0.45)" : "none"};
-  transition: background 0.35s ease, backdrop-filter 0.35s ease,
-    border-bottom 0.35s ease, box-shadow 0.35s ease;
-  isolation: isolate;
-
-  @supports not (backdrop-filter: blur(0)) {
-    backdrop-filter: none;
-    background: ${({ isScrolled }) =>
-      isScrolled
-        ? "rgba(6, 6, 6, 0.94)"
-        : "linear-gradient(180deg, rgba(6, 6, 6, 0.9) 0%, rgba(6, 6, 6, 0.45) 55%, rgba(6, 6, 6, 0) 100%)"};
-  }
-
-  &::after {
-    content: "";
-    position: absolute;
-    z-index: -1;
-    left: 0;
-    right: 0;
-    bottom: -64px;
-    height: 64px;
-    background: linear-gradient(180deg, rgba(6, 6, 6, 0.5) 0%, rgba(6, 6, 6, 0) 100%);
-    opacity: ${({ isScrolled }) => (isScrolled ? 0 : 1)};
-    transition: opacity 0.35s ease;
-    pointer-events: none;
-  }
-
-  @media (max-width: 768px) {
-    background: ${({ isScrolled }) =>
-      isScrolled ? "rgba(6, 6, 6, 0.95)" : "rgba(6, 6, 6, 0.85)"};
-    backdrop-filter: ${({ isScrolled }) => (isScrolled ? "blur(14px)" : "none")};
-  }
+  background: transparent;
 `;
 
 // Navigation Content Wrapper

--- a/src/components/NavigationBar/NavigationBar.view.tsx
+++ b/src/components/NavigationBar/NavigationBar.view.tsx
@@ -43,26 +43,8 @@ export const NavigationBar: React.FC = () => {
   const location = useLocation();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [isScrolled, setIsScrolled] = useState(false);
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const handleScroll = () => {
-      setIsScrolled(window.scrollY > 40);
-    };
-
-    handleScroll();
-    window.addEventListener("scroll", handleScroll);
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
-  }, []);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -112,7 +94,7 @@ export const NavigationBar: React.FC = () => {
   };
 
   return (
-    <NavContainer isScrolled={isScrolled}>
+    <NavContainer>
       <NavContent>
         <NavLeft>
           <LogoSection>


### PR DESCRIPTION
## Summary
- update the navigation bar styling so it sits naturally in the page flow with a transparent background
- remove the scroll state and listener that were only used for sticky styling

## Testing
- npm run lint *(fails due to pre-existing lint errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b62a63208325bef3aec8c7978342