### PR TITLE
Add TMDB-powered search page with filters and trending sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,14 @@ import { theme } from "./theme";
 // import HomePage from "./pages/HomePage";
 // import MovieDetailPage from "./pages/MovieDetailPage";
 import { AuthProvider } from "./contexts";
-import { HomePage, LoginPage, MovieDetailsPage, SignupPage, TVShowDetailsPage } from "./pages";
+import {
+  HomePage,
+  LoginPage,
+  MovieDetailsPage,
+  SearchPage,
+  SignupPage,
+  TVShowDetailsPage,
+} from "./pages";
 
 function App() {
   return (
@@ -25,6 +32,7 @@ function App() {
             <Route path="/" element={<HomePage />} />
             <Route path="/movie/:id" element={<MovieDetailsPage />} />
             <Route path="/tvshow/:id" element={<TVShowDetailsPage />} />
+            <Route path="/search" element={<SearchPage />} />
           </Routes>
         </Router>
       </AuthProvider>

--- a/src/components/NavigationBar/NavigationBar.view.tsx
+++ b/src/components/NavigationBar/NavigationBar.view.tsx
@@ -69,12 +69,24 @@ export const NavigationBar: React.FC = () => {
     navigate("/");
   };
 
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const queryFromParams = params.get("query") ?? "";
+    setSearchQuery((current) =>
+      current === queryFromParams ? current : queryFromParams
+    );
+  }, [location.pathname, location.search]);
+
   const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (searchQuery.trim()) {
-      // TODO: Implement search functionality
-      console.log("Searching for:", searchQuery);
+    const normalizedQuery = searchQuery.trim();
+
+    if (normalizedQuery) {
+      navigate(`/search?query=${encodeURIComponent(normalizedQuery)}`);
+      return;
     }
+
+    navigate("/search");
   };
 
   const getInitials = (name: string) =>

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -6,7 +6,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [user, setUser] = useState<User | null>(null);
 
-  const login = async (email: string, password: string) => {
+  const login = async (email: string, _password: string) => {
     // Simulate API call here
     return new Promise<void>((resolve) => {
       setTimeout(() => {
@@ -21,7 +21,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     });
   };
 
-  const signup = async (username: string, email: string, password: string) => {
+  const signup = async (
+    username: string,
+    email: string,
+    _password: string
+  ) => {
     // Simulate API call here
     return new Promise<void>((resolve) => {
       setTimeout(() => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,16 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import "./index.css";
 import "antd/dist/reset.css";
-import App from './App.tsx'
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+const queryClient = new QueryClient();
+
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>
+);

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,5 +1,6 @@
-export * from "./login";
-export * from "./signup";
-export * from "./home";
-export * from "./movie_details";
-export * from "./tvshow_details";
+export { LoginPage } from "./login";
+export { SignupPage } from "./signup";
+export { HomePage } from "./home";
+export { MovieDetailsPage } from "./movie_details";
+export { TVShowDetailsPage } from "./tvshow_details";
+export { SearchPage } from "./search";

--- a/src/pages/search/SearchPage.styled.ts
+++ b/src/pages/search/SearchPage.styled.ts
@@ -1,0 +1,394 @@
+import styled from "styled-components";
+
+export const PageWrapper = styled.main`
+  background: ${({ theme }) => theme.colors.background};
+  color: ${({ theme }) => theme.colors.text};
+  min-height: 100vh;
+  padding: 4.75rem 3.5rem 5rem;
+
+  @media (max-width: 1200px) {
+    padding: 4rem 2.75rem 4.5rem;
+  }
+
+  @media (max-width: 900px) {
+    padding: 3.5rem 2rem 4rem;
+  }
+
+  @media (max-width: 640px) {
+    padding: 3rem 1.25rem 3.5rem;
+  }
+`;
+
+export const SearchHeader = styled.header`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 1200px;
+  margin: 0 auto 2.5rem;
+
+  @media (max-width: 900px) {
+    margin-bottom: 2rem;
+  }
+`;
+
+export const QueryTitle = styled.h1`
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.75rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+`;
+
+export const QuerySubtitle = styled.p`
+  margin: 0;
+  max-width: 720px;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.72);
+`;
+
+export const ContentLayout = styled.div`
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+  gap: 3rem;
+
+  @media (max-width: 1200px) {
+    gap: 2.5rem;
+  }
+
+  @media (max-width: 1024px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const MainColumn = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+`;
+
+export const TabsList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+`;
+
+export const TabButton = styled.button<{ $active?: boolean }>`
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid
+    ${({ $active }) =>
+      $active ? "rgba(229, 9, 20, 0.85)" : "rgba(255, 255, 255, 0.14)"};
+  background: ${({ $active, theme }) =>
+    $active ? theme.colors.primary : "rgba(255, 255, 255, 0.06)"};
+  color: ${({ $active }) => ($active ? "#fff" : "rgba(255, 255, 255, 0.85)")};
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, background 0.2s ease,
+    border-color 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    transform: translateY(-1px);
+    background: ${({ theme }) => theme.colors.primary};
+    color: #fff;
+    border-color: rgba(229, 9, 20, 0.85);
+  }
+`;
+
+export const FiltersPanel = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+`;
+
+export const FiltersTopRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+`;
+
+export const FiltersTitle = styled.span`
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+`;
+
+export const FilterGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+export const FilterLabel = styled.span`
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.6);
+`;
+
+export const FilterChipsRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+`;
+
+export const FilterChip = styled.button<{ $active?: boolean }>`
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid
+    ${({ $active, theme }) =>
+      $active ? theme.colors.primary : "rgba(255, 255, 255, 0.16)"};
+  background: ${({ $active }) =>
+    $active ? "rgba(229, 9, 20, 0.9)" : "rgba(255, 255, 255, 0.08)"};
+  color: ${({ $active }) => ($active ? "#fff" : "rgba(255, 255, 255, 0.85)")};
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  transition: transform 0.2s ease, background 0.2s ease,
+    border-color 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    transform: translateY(-1px);
+    background: ${({ theme }) => theme.colors.primary};
+    border-color: ${({ theme }) => theme.colors.primary};
+    color: #fff;
+  }
+`;
+
+export const ResetButton = styled.button`
+  align-self: flex-start;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(255, 255, 255, 0.2);
+    transform: translateY(-1px);
+  }
+`;
+
+export const ResultsPanel = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+export const ResultsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.5rem;
+
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const ResultCard = styled.article`
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 1.25rem;
+  padding: 1.1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  min-height: 160px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 90px 1fr;
+    gap: 1rem;
+  }
+
+  @media (max-width: 520px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const PosterWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+  aspect-ratio: 2 / 3;
+`;
+
+export const PosterImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+export const PosterFallback = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.65);
+`;
+
+export const ResultContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+`;
+
+export const ResultTitle = styled.h2`
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+`;
+
+export const ResultMeta = styled.div`
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+`;
+
+export const ResultOverview = styled.p`
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.76);
+  max-height: 4.5em;
+  overflow: hidden;
+`;
+
+export const RatingBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.8rem;
+  font-weight: 600;
+`;
+
+export const EmptyState = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 3rem 2rem;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  border-radius: 18px;
+  color: rgba(255, 255, 255, 0.8);
+`;
+
+export const EmptyTitle = styled.h3`
+  margin: 0;
+  font-size: 1.35rem;
+`;
+
+export const EmptySubtitle = styled.p`
+  margin: 0;
+  color: rgba(255, 255, 255, 0.68);
+  line-height: 1.5;
+`;
+
+export const LoadingState = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 0;
+  color: rgba(255, 255, 255, 0.75);
+  font-weight: 500;
+`;
+
+export const Sidebar = styled.aside`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+export const SidebarCard = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.75rem 1.5rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+`;
+
+export const SidebarHeading = styled.h3`
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+`;
+
+export const TrendingList = styled.ol`
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+`;
+
+export const TrendingItem = styled.li`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.85rem;
+  align-items: center;
+`;
+
+export const TrendingRank = styled.span`
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+`;
+
+export const TrendingInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+`;
+
+export const TrendingTitle = styled.span`
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.92);
+`;
+
+export const TrendingMeta = styled.span`
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+`;
+
+export const SidebarEmptyState = styled.div`
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.68);
+`;

--- a/src/pages/search/SearchPage.view.tsx
+++ b/src/pages/search/SearchPage.view.tsx
@@ -1,0 +1,409 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { NavigationBar } from "../../components";
+import {
+  fetchCombinedGenres,
+  fetchDailyTrending,
+  fetchSearchResults,
+  type SearchFilters,
+  type SearchResult,
+  type SearchTab,
+} from "../../services/api";
+import {
+  ContentLayout,
+  EmptyState,
+  EmptySubtitle,
+  EmptyTitle,
+  FilterChip,
+  FilterChipsRow,
+  FilterGroup,
+  FilterLabel,
+  FiltersPanel,
+  FiltersTitle,
+  FiltersTopRow,
+  LoadingState,
+  MainColumn,
+  PageWrapper,
+  PosterFallback,
+  PosterImage,
+  PosterWrapper,
+  QuerySubtitle,
+  QueryTitle,
+  RatingBadge,
+  ResetButton,
+  ResultCard,
+  ResultContent,
+  ResultMeta,
+  ResultOverview,
+  ResultTitle,
+  ResultsGrid,
+  ResultsPanel,
+  SearchHeader,
+  Sidebar,
+  SidebarCard,
+  SidebarEmptyState,
+  SidebarHeading,
+  TabButton,
+  TabsList,
+  TrendingInfo,
+  TrendingItem,
+  TrendingList,
+  TrendingMeta,
+  TrendingRank,
+  TrendingTitle,
+} from "./SearchPage.styled";
+
+const SEARCH_TABS: { label: string; value: SearchTab }[] = [
+  { label: "All", value: "all" },
+  { label: "Movies & TV", value: "movie_tv" },
+  { label: "Episodes", value: "episodes" },
+  { label: "Similars", value: "similars" },
+];
+
+const TYPE_FILTERS: { label: string; value: NonNullable<SearchFilters["type"]> }[] = [
+  { label: "All Types", value: "all" },
+  { label: "Movies", value: "movie" },
+  { label: "TV Shows", value: "tv" },
+];
+
+const SORT_FILTERS: { label: string; value: NonNullable<SearchFilters["sortBy"]> }[] = [
+  { label: "Most Popular", value: "popularity.desc" },
+  { label: "Top Rated", value: "vote_average.desc" },
+  { label: "Newest First", value: "release_date.desc" },
+];
+
+const CURRENT_YEAR = new Date().getFullYear();
+const YEAR_FILTERS: string[] = Array.from({ length: 8 }, (_, index) =>
+  String(CURRENT_YEAR - index)
+);
+
+const DEFAULT_FILTERS: Required<Pick<SearchFilters, "type" | "sortBy">> &
+  Partial<SearchFilters> = {
+  type: "all",
+  sortBy: "popularity.desc",
+};
+
+const useDebouncedValue = <T,>(value: T, delay = 400) => {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebounced(value), delay);
+    return () => window.clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+};
+
+const formatMediaLabel = (mediaType: SearchResult["media_type"]) => {
+  switch (mediaType) {
+    case "movie":
+      return "Movie";
+    case "tv":
+      return "TV";
+    case "episode":
+      return "Episode";
+    case "person":
+      return "Person";
+    default:
+      return mediaType;
+  }
+};
+
+const formatYear = (date?: string) => {
+  if (!date) {
+    return undefined;
+  }
+
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+
+  return String(parsed.getFullYear());
+};
+
+const fallbackOverview = "No synopsis available yet. Check back soon!";
+
+export const SearchPage: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const initialQuery = searchParams.get("query") ?? "";
+  const [activeTab, setActiveTab] = useState<SearchTab>("all");
+  const [filters, setFilters] = useState<SearchFilters>({ ...DEFAULT_FILTERS });
+
+  const normalizedQuery = initialQuery.trim();
+  const debouncedQuery = useDebouncedValue(normalizedQuery, 450);
+
+  useEffect(() => {
+    setActiveTab("all");
+  }, [normalizedQuery]);
+
+  const { data: genreOptions = [] } = useQuery({
+    queryKey: ["genres", "combined"],
+    queryFn: fetchCombinedGenres,
+    staleTime: 1000 * 60 * 60,
+  });
+
+  const topGenres = useMemo(
+    () => (genreOptions.length > 0 ? genreOptions.slice(0, 12) : []),
+    [genreOptions]
+  );
+
+  const { data: searchResults = [], isPending: isSearchPending } = useQuery({
+    queryKey: ["search", { query: debouncedQuery, tab: activeTab, filters }],
+    queryFn: () =>
+      fetchSearchResults({
+        query: debouncedQuery,
+        tab: activeTab,
+        filters,
+      }),
+    enabled: debouncedQuery.length > 0,
+    staleTime: 1000 * 60,
+  });
+
+  const { data: trendingResults = [] } = useQuery({
+    queryKey: ["trending", "daily"],
+    queryFn: fetchDailyTrending,
+    staleTime: 1000 * 60 * 60,
+  });
+
+  const handleTypeChange = (value: NonNullable<SearchFilters["type"]>) => {
+    setFilters((previous) => ({ ...previous, type: value }));
+  };
+
+  const handleGenreToggle = (genreId: number) => {
+    setFilters((previous) => ({
+      ...previous,
+      genreId: previous.genreId === genreId ? undefined : genreId,
+    }));
+  };
+
+  const handleYearToggle = (year: string) => {
+    setFilters((previous) => ({
+      ...previous,
+      year: previous.year === year ? undefined : year,
+    }));
+  };
+
+  const handleSortChange = (value: NonNullable<SearchFilters["sortBy"]>) => {
+    setFilters((previous) => ({ ...previous, sortBy: value }));
+  };
+
+  const handleResetFilters = () => {
+    setFilters({ ...DEFAULT_FILTERS });
+  };
+
+  const hasQuery = debouncedQuery.length > 0;
+  const hasResults = searchResults.length > 0;
+
+  return (
+    <>
+      <NavigationBar />
+      <PageWrapper>
+        <SearchHeader>
+          <QueryTitle>Search</QueryTitle>
+          <QuerySubtitle>
+            {hasQuery
+              ? `Results for "${debouncedQuery}"`
+              : "Use the search bar to discover movies, shows, and more."}
+          </QuerySubtitle>
+        </SearchHeader>
+
+        <ContentLayout>
+          <MainColumn>
+            <TabsList role="tablist">
+              {SEARCH_TABS.map((tab) => (
+                <TabButton
+                  key={tab.value}
+                  type="button"
+                  role="tab"
+                  aria-selected={activeTab === tab.value}
+                  $active={activeTab === tab.value}
+                  onClick={() => setActiveTab(tab.value)}
+                >
+                  {tab.label}
+                </TabButton>
+              ))}
+            </TabsList>
+
+            <FiltersPanel>
+              <FiltersTopRow>
+                <FiltersTitle>Filters</FiltersTitle>
+                <ResetButton type="button" onClick={handleResetFilters}>
+                  Reset
+                </ResetButton>
+              </FiltersTopRow>
+
+              <FilterGroup>
+                <FilterLabel>Type</FilterLabel>
+                <FilterChipsRow>
+                  {TYPE_FILTERS.map((option) => (
+                    <FilterChip
+                      key={option.value}
+                      type="button"
+                      $active={filters.type === option.value}
+                      onClick={() => handleTypeChange(option.value)}
+                    >
+                      {option.label}
+                    </FilterChip>
+                  ))}
+                </FilterChipsRow>
+              </FilterGroup>
+
+              {topGenres.length > 0 && (
+                <FilterGroup>
+                  <FilterLabel>Genre</FilterLabel>
+                  <FilterChipsRow>
+                    {topGenres.map((genre) => (
+                      <FilterChip
+                        key={genre.id}
+                        type="button"
+                        $active={filters.genreId === genre.id}
+                        onClick={() => handleGenreToggle(genre.id)}
+                      >
+                        {genre.name}
+                      </FilterChip>
+                    ))}
+                  </FilterChipsRow>
+                </FilterGroup>
+              )}
+
+              <FilterGroup>
+                <FilterLabel>Year</FilterLabel>
+                <FilterChipsRow>
+                  {YEAR_FILTERS.map((year) => (
+                    <FilterChip
+                      key={year}
+                      type="button"
+                      $active={filters.year === year}
+                      onClick={() => handleYearToggle(year)}
+                    >
+                      {year}
+                    </FilterChip>
+                  ))}
+                </FilterChipsRow>
+              </FilterGroup>
+
+              <FilterGroup>
+                <FilterLabel>Sort By</FilterLabel>
+                <FilterChipsRow>
+                  {SORT_FILTERS.map((option) => (
+                    <FilterChip
+                      key={option.value}
+                      type="button"
+                      $active={filters.sortBy === option.value}
+                      onClick={() => handleSortChange(option.value)}
+                    >
+                      {option.label}
+                    </FilterChip>
+                  ))}
+                </FilterChipsRow>
+              </FilterGroup>
+            </FiltersPanel>
+
+            <ResultsPanel>
+              {!hasQuery && (
+                <EmptyState>
+                  <EmptyTitle>Ready to explore?</EmptyTitle>
+                  <EmptySubtitle>
+                    Start typing in the search bar to look for titles, genres, or
+                    people. We&rsquo;ll surface the best matches instantly.
+                  </EmptySubtitle>
+                </EmptyState>
+              )}
+
+              {hasQuery && isSearchPending && <LoadingState>Loading results…</LoadingState>}
+
+              {hasQuery && !isSearchPending && !hasResults && (
+                <EmptyState>
+                  <EmptyTitle>No matches just yet</EmptyTitle>
+                  <EmptySubtitle>
+                    We couldn&rsquo;t find anything for "{debouncedQuery}" with the
+                    current filters. Try adjusting them or searching for another
+                    title.
+                  </EmptySubtitle>
+                </EmptyState>
+              )}
+
+              {hasResults && (
+                <ResultsGrid>
+                  {searchResults.map((result) => {
+                    const mediaLabel = formatMediaLabel(result.media_type);
+                    const releaseYear = formatYear(result.releaseDate);
+                    const posterInitial = result.title.charAt(0).toUpperCase();
+
+                    return (
+                      <ResultCard
+                        key={`${result.media_type}-${result.id}`}
+                        aria-label={`${mediaLabel}: ${result.title}`}
+                      >
+                        <PosterWrapper>
+                          {result.posterUrl ? (
+                            <PosterImage
+                              src={result.posterUrl}
+                              alt={result.title}
+                              loading="lazy"
+                            />
+                          ) : (
+                            <PosterFallback aria-hidden="true">
+                              {posterInitial}
+                            </PosterFallback>
+                          )}
+                        </PosterWrapper>
+                        <ResultContent>
+                          <ResultTitle>{result.title}</ResultTitle>
+                          <ResultMeta>
+                            <span>{mediaLabel}</span>
+                            {releaseYear && <span>{releaseYear}</span>}
+                            {typeof result.voteAverage === "number" && result.voteAverage > 0 && (
+                              <RatingBadge>⭐ {result.voteAverage.toFixed(1)}</RatingBadge>
+                            )}
+                          </ResultMeta>
+                          <ResultOverview>
+                            {result.overview || fallbackOverview}
+                          </ResultOverview>
+                        </ResultContent>
+                      </ResultCard>
+                    );
+                  })}
+                </ResultsGrid>
+              )}
+            </ResultsPanel>
+          </MainColumn>
+
+          <Sidebar>
+            <SidebarCard>
+              <SidebarHeading>Trending Today</SidebarHeading>
+              {trendingResults.length === 0 ? (
+                <SidebarEmptyState>
+                  Trending titles are warming up. Check back soon!
+                </SidebarEmptyState>
+              ) : (
+                <TrendingList>
+                  {trendingResults.slice(0, 8).map((item, index) => {
+                    const mediaLabel = formatMediaLabel(item.media_type);
+                    const releaseYear = formatYear(item.releaseDate);
+
+                    return (
+                      <TrendingItem key={`${item.media_type}-${item.id}`}>
+                        <TrendingRank>{index + 1}</TrendingRank>
+                        <TrendingInfo>
+                          <TrendingTitle>{item.title}</TrendingTitle>
+                          <TrendingMeta>
+                            {[mediaLabel, releaseYear]
+                              .filter(Boolean)
+                              .join(" • ")}
+                          </TrendingMeta>
+                        </TrendingInfo>
+                      </TrendingItem>
+                    );
+                  })}
+                </TrendingList>
+              )}
+            </SidebarCard>
+          </Sidebar>
+        </ContentLayout>
+      </PageWrapper>
+    </>
+  );
+};

--- a/src/pages/search/index.ts
+++ b/src/pages/search/index.ts
@@ -1,0 +1,1 @@
+export { SearchPage } from "./SearchPage.view";

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -13,6 +13,185 @@ const apiClient = axios.create({
   },
 });
 
+const IMAGE_BASE_URL = "https://image.tmdb.org/t/p";
+const DEFAULT_POSTER_SIZE = "w500";
+
+export type SupportedMediaType = "movie" | "tv" | "person" | "episode";
+
+export interface SearchFilters {
+  type?: "all" | "movie" | "tv";
+  genreId?: number;
+  year?: string;
+  sortBy?: "popularity.desc" | "vote_average.desc" | "release_date.desc";
+}
+
+export type SearchTab = "all" | "movie_tv" | "episodes" | "similars";
+
+export interface SearchResult {
+  id: number;
+  media_type: SupportedMediaType;
+  title: string;
+  overview: string;
+  posterUrl?: string;
+  backdropUrl?: string;
+  releaseDate?: string;
+  voteAverage?: number | null;
+  popularity?: number | null;
+  originalTitle?: string;
+}
+
+export interface SearchQueryOptions {
+  query: string;
+  tab: SearchTab;
+  filters?: SearchFilters;
+}
+
+const createImageUrl = (path?: string | null, size: string = DEFAULT_POSTER_SIZE) =>
+  path ? `${IMAGE_BASE_URL}/${size}${path}` : undefined;
+
+const resolveMediaType = (
+  item: Record<string, unknown>,
+  override?: SupportedMediaType
+): SupportedMediaType => {
+  if (override) {
+    return override;
+  }
+
+  if (typeof item.media_type === "string") {
+    return item.media_type as SupportedMediaType;
+  }
+
+  if ("episode_type" in item) {
+    return "episode";
+  }
+
+  if ("title" in item || "original_title" in item) {
+    return "movie";
+  }
+
+  return "tv";
+};
+
+const mapSearchResult = (
+  item: Record<string, any>,
+  override?: SupportedMediaType
+): SearchResult => {
+  const mediaType = resolveMediaType(item, override);
+  const releaseDate =
+    item.release_date ??
+    item.first_air_date ??
+    item.air_date ??
+    item.episode_air_date ??
+    undefined;
+
+  const posterPath =
+    item.poster_path ?? item.profile_path ?? item.still_path ?? null;
+
+  return {
+    id: item.id,
+    media_type: mediaType,
+    title:
+      item.title ??
+      item.name ??
+      item.original_name ??
+      item.original_title ??
+      "Untitled",
+    overview: item.overview ?? "",
+    posterUrl: createImageUrl(
+      posterPath,
+      mediaType === "episode" ? "w300" : DEFAULT_POSTER_SIZE
+    ),
+    backdropUrl: createImageUrl(item.backdrop_path ?? null, "w780"),
+    releaseDate,
+    voteAverage:
+      typeof item.vote_average === "number" ? item.vote_average : null,
+    popularity: typeof item.popularity === "number" ? item.popularity : null,
+    originalTitle:
+      item.original_title ?? item.original_name ?? undefined,
+  };
+};
+
+const applySearchFilters = (
+  items: Record<string, any>[],
+  filters?: SearchFilters
+) => {
+  if (!filters) {
+    return items;
+  }
+
+  const { type, genreId, year, sortBy } = filters;
+  let filteredItems = items;
+
+  if (type && type !== "all") {
+    filteredItems = filteredItems.filter((item) => {
+      const mediaType = resolveMediaType(item);
+      if (type === "movie") {
+        return mediaType === "movie";
+      }
+      if (type === "tv") {
+        return mediaType === "tv" || mediaType === "episode";
+      }
+      return true;
+    });
+  }
+
+  if (genreId) {
+    filteredItems = filteredItems.filter((item) => {
+      const genreIds =
+        item.genre_ids ??
+        (Array.isArray(item.genres)
+          ? item.genres.map((genre: { id: number }) => genre.id)
+          : []);
+      return Array.isArray(genreIds) && genreIds.includes(genreId);
+    });
+  }
+
+  if (year) {
+    filteredItems = filteredItems.filter((item) => {
+      const dateString =
+        item.release_date ??
+        item.first_air_date ??
+        item.air_date ??
+        item.episode_air_date ??
+        "";
+      return typeof dateString === "string" && dateString.startsWith(year);
+    });
+  }
+
+  if (sortBy) {
+    const [field, direction] = sortBy.split(".");
+    const multiplier = direction === "asc" ? 1 : -1;
+    filteredItems = [...filteredItems].sort((a, b) => {
+      const resolveValue = (entry: Record<string, any>) => {
+        switch (field) {
+          case "vote_average":
+            return typeof entry.vote_average === "number"
+              ? entry.vote_average
+              : 0;
+          case "release_date":
+            return Date.parse(
+              entry.release_date ??
+                entry.first_air_date ??
+                entry.air_date ??
+                entry.episode_air_date ??
+                "0"
+            );
+          default:
+            return typeof entry.popularity === "number"
+              ? entry.popularity
+              : 0;
+        }
+      };
+
+      const aValue = resolveValue(a);
+      const bValue = resolveValue(b);
+      return (aValue - bValue) * multiplier;
+    });
+  }
+
+  return filteredItems;
+};
+
 // Fetch Movie API Data by Category
 export const fetchMoviesByCategory = async (
   category: string
@@ -62,4 +241,131 @@ export const fetchGenres = async (): Promise<
     params: { language: "en-US" },
   });
   return response.data.genres;
+};
+
+export const fetchCombinedGenres = async (): Promise<
+  { id: number; name: string }[]
+> => {
+  const [movieGenresResponse, tvGenresResponse] = await Promise.all([
+    apiClient.get("/genre/movie/list", { params: { language: "en-US" } }),
+    apiClient.get("/genre/tv/list", { params: { language: "en-US" } }),
+  ]);
+
+  const genresMap = new Map<number, { id: number; name: string }>();
+
+  (movieGenresResponse.data.genres ?? []).forEach(
+    (genre: { id: number; name: string }) => {
+      genresMap.set(genre.id, genre);
+    }
+  );
+
+  (tvGenresResponse.data.genres ?? []).forEach(
+    (genre: { id: number; name: string }) => {
+      if (!genresMap.has(genre.id)) {
+        genresMap.set(genre.id, genre);
+      }
+    }
+  );
+
+  return Array.from(genresMap.values()).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+};
+
+export const fetchSearchResults = async ({
+  query,
+  tab,
+  filters,
+}: SearchQueryOptions): Promise<SearchResult[]> => {
+  const sanitizedQuery = query.trim();
+
+  if (!sanitizedQuery) {
+    return [];
+  }
+
+  if (tab === "episodes") {
+    const response = await apiClient.get("/search/tv", {
+      params: {
+        query: sanitizedQuery,
+        include_adult: false,
+        language: "en-US",
+        search_type: "episode",
+      },
+    });
+
+    const results =
+      response.data.results?.map((item: Record<string, any>) => ({
+        ...item,
+        media_type: "episode",
+      })) ?? [];
+
+    const filtered = applySearchFilters(results, filters);
+    return filtered.map((item) => mapSearchResult(item, "episode"));
+  }
+
+  if (tab === "similars") {
+    const seedResponse = await apiClient.get("/search/multi", {
+      params: {
+        query: sanitizedQuery,
+        include_adult: false,
+        language: "en-US",
+      },
+    });
+
+    const seedResults: Record<string, any>[] = seedResponse.data.results ?? [];
+    const seedTitle = seedResults.find(
+      (item) =>
+        item && (item.media_type === "movie" || item.media_type === "tv")
+    );
+
+    if (!seedTitle) {
+      return [];
+    }
+
+    const similarResponse = await apiClient.get(
+      `/${seedTitle.media_type}/${seedTitle.id}/similar`,
+      {
+        params: {
+          language: "en-US",
+        },
+      }
+    );
+
+    const similarResults: Record<string, any>[] =
+      similarResponse.data.results ?? [];
+    const filtered = applySearchFilters(similarResults, filters);
+
+    return filtered.map((item) =>
+      mapSearchResult(item, seedTitle.media_type as SupportedMediaType)
+    );
+  }
+
+  const response = await apiClient.get("/search/multi", {
+    params: {
+      query: sanitizedQuery,
+      include_adult: false,
+      language: "en-US",
+    },
+  });
+
+  let results: Record<string, any>[] = response.data.results ?? [];
+
+  if (tab === "movie_tv") {
+    results = results.filter(
+      (item) => item.media_type === "movie" || item.media_type === "tv"
+    );
+  }
+
+  const filtered = applySearchFilters(results, filters);
+
+  return filtered.map((item) => mapSearchResult(item));
+};
+
+export const fetchDailyTrending = async (): Promise<SearchResult[]> => {
+  const response = await apiClient.get("/trending/all/day", {
+    params: { language: "en-US" },
+  });
+
+  const results: Record<string, any>[] = response.data.results ?? [];
+  return results.map((item) => mapSearchResult(item));
 };

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,6 +2,7 @@ export const theme = {
   colors: {
     primary: "#e50914",
     background: "#0D0D0D",
+    textLight: "#b3b3b3",
     text: "#fff",
   },
 };

--- a/src/types/react-slick.d.ts
+++ b/src/types/react-slick.d.ts
@@ -1,0 +1,1 @@
+declare module "react-slick";


### PR DESCRIPTION
## Summary
- add a dedicated search page with tabbed views, filter chips, empty states, and a trending sidebar powered by React Query
- extend TMDB API helpers with reusable search, genre, similar-title, and trending queries
- wire the navigation search form and root router to the new search route and register React Query globally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0b9d8a8508325979bd665ff07f9c1