### PR TITLE
Use home cards on search results

### DIFF
--- a/src/components/NavigationBar/NavigationBar.styled.ts
+++ b/src/components/NavigationBar/NavigationBar.styled.ts
@@ -18,7 +18,7 @@ export const NavContent = styled.div`
   gap: 2rem;
   padding: 0 3rem;
   height: 76px;
-  max-width: 1300px;
+  max-width: 1680px;
   margin: 0 auto;
   width: 100%;
 

--- a/src/pages/search/SearchPage.styled.ts
+++ b/src/pages/search/SearchPage.styled.ts
@@ -23,7 +23,7 @@ export const SearchHeader = styled.header`
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  max-width: 1200px;
+  max-width: 1680px;
   margin: 0 auto 2.5rem;
 
   @media (max-width: 900px) {
@@ -140,7 +140,7 @@ export const QuerySubtitle = styled.p`
 `;
 
 export const ContentLayout = styled.div`
-  max-width: 1200px;
+  max-width: 1680px;
   margin: 0 auto;
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
@@ -289,12 +289,19 @@ export const ResultsPanel = styled.section`
 
 export const ResultsGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+  justify-items: center;
 
   @media (max-width: 640px) {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   }
+`;
+
+export const ResultCardWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
 `;
 
 export const ResultCard = styled.article`


### PR DESCRIPTION
## Summary
- reuse the existing MovieCard and TVShowCard components on the search page while loading trending titles by default and combining movie/TV results
- move the filter panel into the sidebar, remove the old tabs, and expand the page/navigation max widths to 1680px with an updated grid layout
- extend the search API mapping utilities to expose poster/backdrop paths and genre ids for reuse by the shared cards

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d104e2652883258c209e32b16dd924